### PR TITLE
Refresh anomaly

### DIFF
--- a/app/javascript/components/workflows/student/exams/show/lockdown/listeners.ts
+++ b/app/javascript/components/workflows/student/exams/show/lockdown/listeners.ts
@@ -40,6 +40,14 @@ const listeners: {
       detected('tried context menu', e);
     },
   },
+  {
+    event: 'beforeunload',
+    handler: (detected) => (e: Event): void => {
+      e.preventDefault();
+      e.stopPropagation();
+      detected('tried to navigate away', e);
+    },
+  },
 ];
 
 export function installListeners(policies: Policy[], detected: AnomalyDetected): AnomalyListener[] {

--- a/test/fixtures/files/cs2500midterm-v2/exam.yaml
+++ b/test/fixtures/files/cs2500midterm-v2/exam.yaml
@@ -1,7 +1,5 @@
 ---
-policies:
-  - ignore-lockdown
-  - tolerate-windowed
+policies: []
 contents:
   instructions: Instructions go here.
   reference:


### PR DESCRIPTION
Closes #46 by adding a listener for `beforeunload`.