### PR TITLE
change handling of refresh anomaly

### DIFF
--- a/app/javascript/components/workflows/index.tsx
+++ b/app/javascript/components/workflows/index.tsx
@@ -161,8 +161,8 @@ const BlockerContext = React.createContext({} as BlockerContext);
 export const BlockNav: React.FC<{
   when?: boolean;
   message: string;
-  onStay: () => void;
-  onLeave: () => void;
+  onStay?: () => void;
+  onLeave?: () => void;
 }> = (props) => {
   const {
     when = true,
@@ -173,11 +173,8 @@ export const BlockNav: React.FC<{
   const { setCustomHandler } = useContext(BlockerContext);
   useEffect(() => {
     setCustomHandler(() => (b) => {
-      if (b) {
-        onLeave();
-      } else {
-        onStay();
-      }
+      if (b && onLeave) onLeave();
+      if (!b && onStay) onStay();
     });
   }, [onStay, onLeave]);
   return (

--- a/app/javascript/components/workflows/index.tsx
+++ b/app/javascript/components/workflows/index.tsx
@@ -1,10 +1,10 @@
 import { hot } from 'react-hot-loader';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { RailsContext } from '@student/exams/show/context';
 import RegularNavbar from '@hourglass/common/navbar';
-import { Container } from 'react-bootstrap';
+import { Container, Modal, Button } from 'react-bootstrap';
 import {
   BrowserRouter,
   Link,
@@ -26,6 +26,7 @@ import { AllAlerts } from '@hourglass/common/alerts';
 import AllocateVersions from '@professor/exams/allocate-versions';
 import AssignStaff from '@professor/exams/assign-staff';
 import './index.scss';
+import ReactDOM from 'react-dom';
 
 interface StudentRegsProps {
   regs: ApiStudentReg.Reg[];
@@ -152,6 +153,10 @@ const Exam: React.FC = () => {
 const Entry: React.FC = () => {
   const res = ApiMe.useResponse();
   const railsUser = res.type === 'RESULT' ? res.response.user : undefined;
+
+  const [transitioning, setTransitioning] = useState(false);
+  const [transitionMessage, setTransitionMessage] = useState('');
+  const [transitionCallback, setTransitionCallback] = useState(() => (_) => undefined);
   return (
     <RailsContext.Provider
       value={{
@@ -159,7 +164,47 @@ const Entry: React.FC = () => {
       }}
     >
       <DndProvider backend={HTML5Backend}>
-        <BrowserRouter>
+        <BrowserRouter
+          getUserConfirmation={(message, callback) => {
+            setTransitioning(true);
+            setTransitionMessage(message);
+            setTransitionCallback(() => callback);
+          }}
+        >
+          <Modal
+            show={transitioning}
+            onHide={() => {
+              setTransitioning(false);
+              transitionCallback(false);
+            }}
+          >
+            <Modal.Header closeButton>
+              <Modal.Title>Are you sure you want to navigate?</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+              {transitionMessage}
+            </Modal.Body>
+            <Modal.Footer>
+              <Button
+                variant="primary"
+                onClick={() => {
+                  setTransitioning(false);
+                  transitionCallback(false);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="danger"
+                onClick={() => {
+                  setTransitioning(false);
+                  transitionCallback(true);
+                }}
+              >
+                Leave
+              </Button>
+            </Modal.Footer>
+          </Modal>
           <Switch>
             <Route path="/exams/:examId" exact>
               <Exam />

--- a/app/javascript/components/workflows/index.tsx
+++ b/app/javascript/components/workflows/index.tsx
@@ -174,7 +174,10 @@ export const BlockNav: React.FC<{
   useEffect(() => {
     setCustomHandler(() => (b) => {
       if (b && onLeave) onLeave();
-      if (!b && onStay) onStay();
+      if (!b) {
+        if (onStay) onStay();
+        window.history.pushState({}, document.title);
+      }
     });
   }, [onStay, onLeave]);
   return (
@@ -216,8 +219,8 @@ const Entry: React.FC = () => {
               show={transitioning}
               onHide={() => {
                 setTransitioning(false);
-                customHandler(false);
                 transitionCallback(false);
+                customHandler(false);
               }}
             >
               <Modal.Header closeButton>
@@ -231,8 +234,8 @@ const Entry: React.FC = () => {
                   variant="primary"
                   onClick={() => {
                     setTransitioning(false);
-                    customHandler(false);
                     transitionCallback(false);
+                    customHandler(false);
                   }}
                 >
                   Cancel
@@ -241,8 +244,8 @@ const Entry: React.FC = () => {
                   variant="danger"
                   onClick={() => {
                     setTransitioning(false);
-                    customHandler(true);
                     transitionCallback(true);
+                    customHandler(true);
                   }}
                 >
                   Leave

--- a/app/javascript/components/workflows/student/exams/show/actions/index.ts
+++ b/app/javascript/components/workflows/student/exams/show/actions/index.ts
@@ -263,6 +263,7 @@ export function doTryLockdown(
 ): Thunk {
   return (dispatch): void => {
     lock(exam.policies).then(() => {
+      window.history.pushState({}, document.title);
       if (policyPermits(exam.policies, Policy.ignoreLockdown)) {
         dispatch(lockdownIgnored());
       } else {

--- a/app/javascript/components/workflows/student/exams/show/components/ExamShowContents.tsx
+++ b/app/javascript/components/workflows/student/exams/show/components/ExamShowContents.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useEffect, useContext, useCallback } from 'react';
 import {
   ExamVersion,
 } from '@student/exams/show/types';
@@ -9,10 +9,12 @@ import HTML from '@student/exams/show/components/HTML';
 import { Row, Col } from 'react-bootstrap';
 import { FileViewer } from '@student/exams/show/components/FileViewer';
 import ShowQuestion from '@student/exams/show/containers/ShowQuestion';
+import { BlockNav } from '@hourglass/workflows';
 
 interface ExamShowContentsProps {
   exam: ExamVersion;
   save: () => void;
+  submit: () => void;
 }
 
 const INTERVAL = 10000;
@@ -21,7 +23,11 @@ const ExamShowContents: React.FC<ExamShowContentsProps> = (props) => {
   const {
     exam,
     save,
+    submit,
   } = props;
+  const leave = useCallback(() => {
+    submit();
+  }, []);
   useEffect(() => {
     const timer: number = window.setInterval(() => save(), INTERVAL);
     return (): void => {
@@ -39,6 +45,10 @@ const ExamShowContents: React.FC<ExamShowContentsProps> = (props) => {
   const { railsExam } = useContext(RailsContext);
   return (
     <ExamContext.Provider value={{ files, fmap }}>
+      <BlockNav
+        onLeave={leave}
+        message="Are you sure you want to navigate away? Your exam will be submitted."
+      />
       <ExamFilesContext.Provider value={{ references: reference }}>
         <h1>{railsExam.name}</h1>
         <HTML value={instructions} />

--- a/app/javascript/components/workflows/student/exams/show/components/ExamShowContents.tsx
+++ b/app/javascript/components/workflows/student/exams/show/components/ExamShowContents.tsx
@@ -27,7 +27,7 @@ const ExamShowContents: React.FC<ExamShowContentsProps> = (props) => {
   } = props;
   const leave = useCallback(() => {
     submit();
-  }, []);
+  }, [submit]);
   useEffect(() => {
     const timer: number = window.setInterval(() => save(), INTERVAL);
     return (): void => {

--- a/app/javascript/components/workflows/student/exams/show/components/ExamTaker.tsx
+++ b/app/javascript/components/workflows/student/exams/show/components/ExamTaker.tsx
@@ -6,7 +6,6 @@ import { RailsContext } from '@student/exams/show/context';
 import ExamShowContents from '@student/exams/show/containers/ExamShowContents';
 import PreStart from '@student/exams/show/containers/PreStart';
 import './ExamTaker.scss';
-import { BlockNav } from '@hourglass/workflows';
 
 interface ExamTakerProps {
   ready: boolean;
@@ -20,20 +19,9 @@ const ExamTaker: React.FC<ExamTakerProps> = (props) => {
     railsCourse,
     railsExam,
   } = useContext(RailsContext);
-  const stay = useCallback(() => {
-    console.log('chose stay');
-  }, []);
-  const leave = useCallback(() => {
-    console.log('chose leave');
-  }, []);
   const body = ready ? (
     <div id="exam-taker" className="d-flex">
       <ExamNavbar />
-      <BlockNav
-        onStay={stay}
-        onLeave={leave}
-        message="Are you sure you want to navigate away? Your exam will be submitted."
-      />
       <Container fluid className="flex-fill transition">
         <Row
           id="exam-body"

--- a/app/javascript/components/workflows/student/exams/show/components/ExamTaker.tsx
+++ b/app/javascript/components/workflows/student/exams/show/components/ExamTaker.tsx
@@ -6,7 +6,6 @@ import { RailsContext } from '@student/exams/show/context';
 import ExamShowContents from '@student/exams/show/containers/ExamShowContents';
 import PreStart from '@student/exams/show/containers/PreStart';
 import './ExamTaker.scss';
-import { Prompt } from 'react-router-dom';
 import { BlockNav } from '@hourglass/workflows';
 
 interface ExamTakerProps {

--- a/app/javascript/components/workflows/student/exams/show/components/ExamTaker.tsx
+++ b/app/javascript/components/workflows/student/exams/show/components/ExamTaker.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useCallback } from 'react';
 import ExamNavbar from '@student/exams/show/containers/navbar';
 import RegularNavbar from '@hourglass/common/navbar';
 import { Row, Col, Container } from 'react-bootstrap';
@@ -6,6 +6,8 @@ import { RailsContext } from '@student/exams/show/context';
 import ExamShowContents from '@student/exams/show/containers/ExamShowContents';
 import PreStart from '@student/exams/show/containers/PreStart';
 import './ExamTaker.scss';
+import { Prompt } from 'react-router-dom';
+import { BlockNav } from '@hourglass/workflows';
 
 interface ExamTakerProps {
   ready: boolean;
@@ -19,9 +21,20 @@ const ExamTaker: React.FC<ExamTakerProps> = (props) => {
     railsCourse,
     railsExam,
   } = useContext(RailsContext);
+  const stay = useCallback(() => {
+    console.log('chose stay');
+  }, []);
+  const leave = useCallback(() => {
+    console.log('chose leave');
+  }, []);
   const body = ready ? (
     <div id="exam-taker" className="d-flex">
       <ExamNavbar />
+      <BlockNav
+        onStay={stay}
+        onLeave={leave}
+        message="Are you sure you want to navigate away? Your exam will be submitted."
+      />
       <Container fluid className="flex-fill transition">
         <Row
           id="exam-body"

--- a/app/javascript/components/workflows/student/exams/show/components/ExamTaker.tsx
+++ b/app/javascript/components/workflows/student/exams/show/components/ExamTaker.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useCallback } from 'react';
+import React, { useContext } from 'react';
 import ExamNavbar from '@student/exams/show/containers/navbar';
 import RegularNavbar from '@hourglass/common/navbar';
 import { Row, Col, Container } from 'react-bootstrap';

--- a/app/javascript/components/workflows/student/exams/show/containers/ExamShowContents.ts
+++ b/app/javascript/components/workflows/student/exams/show/containers/ExamShowContents.ts
@@ -1,6 +1,6 @@
 import ExamShowContents from '@student/exams/show/components/ExamShowContents';
 import { connect } from 'react-redux';
-import { saveSnapshot } from '@student/exams/show/actions';
+import { saveSnapshot, submitExam } from '@student/exams/show/actions';
 import {
   ExamVersion,
   MSTP,
@@ -20,9 +20,13 @@ const mapStateToProps: MSTP<{exam: ExamVersion}, OwnProps> = (state) => ({
 
 const mapDispatchToProps: MDTP<{
   save: () => void;
+  submit: () => void;
 }, OwnProps> = (dispatch, ownProps) => ({
   save: (): void => {
     dispatch(saveSnapshot(ownProps.railsCourse.id, ownProps.railsExam.id));
+  },
+  submit: (): void => {
+    dispatch(submitExam(ownProps.railsCourse.id, ownProps.railsExam.id));
   },
 });
 

--- a/app/javascript/components/workflows/student/exams/show/lockdown/listeners.ts
+++ b/app/javascript/components/workflows/student/exams/show/lockdown/listeners.ts
@@ -46,18 +46,6 @@ const listeners: {
       detected('tried to navigate away', e);
     },
   },
-  {
-    event: 'popstate',
-    handler: (detected) => (e: Event): void => {
-      detected('tried to navigate back', e);
-    },
-  },
-  {
-    event: 'pushstate',
-    handler: (detected) => (e: Event): void => {
-      detected('tried to navigate forward', e);
-    },
-  },
 ];
 
 export function installListeners(policies: Policy[], detected: AnomalyDetected): AnomalyListener[] {

--- a/app/javascript/components/workflows/student/exams/show/lockdown/listeners.ts
+++ b/app/javascript/components/workflows/student/exams/show/lockdown/listeners.ts
@@ -49,7 +49,13 @@ const listeners: {
   {
     event: 'popstate',
     handler: (detected) => (e: Event): void => {
-      detected('tried to change pages', e);
+      detected('tried to navigate back', e);
+    },
+  },
+  {
+    event: 'pushstate',
+    handler: (detected) => (e: Event): void => {
+      detected('tried to navigate forward', e);
     },
   },
 ];


### PR DESCRIPTION
- [x] detect `pushstate`
- [x] ask user if they are sure they want to navigate and submit instead of anomaly
  - https://github.com/CodeGrade/hourglass/pull/113#discussion_r439516903

`BlockNav` will catch `pushstate` and `popstate`, and ask the user if they are sure. If they are, lockdown is lifted and the exam is submitted.

`beforeunload` is still installed as a regular listener that triggers anomalies for Ctrl-R, or back/forward to other sites.