### PR TITLE
Fix archive extraction on macOS

### DIFF
--- a/app/controllers/api/professor/versions_controller.rb
+++ b/app/controllers/api/professor/versions_controller.rb
@@ -36,7 +36,7 @@ module Api
 
       def export_archive
         fname = @version.name.gsub(/ /, '-') + '.zip'
-        Dir.mktmpdir do |path|
+        ArchiveUtils.mktmpdir do |path|
           pathname = Pathname.new(path)
           zip_path = pathname.join(fname)
           contents_path = pathname.join('exam-contents')

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -35,7 +35,7 @@ class Upload
     @upload_data = @upload.read
     @files = []
     @info = {}
-    @dir = Pathname.new(Dir.mktmpdir)
+    @dir = Pathname.new(ArchiveUtils.mktmpdir)
     extract_contents!
     parse_info!
     purge!

--- a/lib/archive_utils.rb
+++ b/lib/archive_utils.rb
@@ -104,7 +104,6 @@ end
 
 # Utility class for uniformly dealing with archives
 class ArchiveUtils
-
   def self.mktmpdir
     path = File.realdirpath(Dir.mktmpdir)
     if block_given?

--- a/lib/archive_utils.rb
+++ b/lib/archive_utils.rb
@@ -575,7 +575,7 @@ class ArchiveUtils
       out = encode_or_escape(File.join(dest, entry.name.gsub('\\', '/').sub(%r{/$}, '')))
       next if out.to_s.match?('__MACOSX') || out.to_s.match?('.DS_Store')
 
-      if (safe_realdir(out).starts_with?(dest.to_s) rescue false)
+      if (safe_realdir(out).starts_with?(File.realdirpath(dest).to_s) rescue false)
         if entry.directory?
           FileUtils.rm_rf out unless File.directory? out
           FileUtils.mkdir_p out, mode: entry.unix_perms, verbose: false

--- a/lib/archive_utils.rb
+++ b/lib/archive_utils.rb
@@ -104,6 +104,16 @@ end
 
 # Utility class for uniformly dealing with archives
 class ArchiveUtils
+
+  def self.mktmpdir
+    path = File.realdirpath(Dir.mktmpdir)
+    if block_given?
+      yield path
+    else
+      path
+    end
+  end
+
   ###############################
   ## Zip file creation
   ###############################
@@ -575,7 +585,7 @@ class ArchiveUtils
       out = encode_or_escape(File.join(dest, entry.name.gsub('\\', '/').sub(%r{/$}, '')))
       next if out.to_s.match?('__MACOSX') || out.to_s.match?('.DS_Store')
 
-      if (safe_realdir(out).starts_with?(File.realdirpath(dest).to_s) rescue false)
+      if (safe_realdir(out).starts_with?(dest.to_s) rescue false)
         if entry.directory?
           FileUtils.rm_rf out unless File.directory? out
           FileUtils.mkdir_p out, mode: entry.unix_perms, verbose: false

--- a/test/helpers/upload.rb
+++ b/test/helpers/upload.rb
@@ -2,7 +2,7 @@
 
 module UploadTestHelper
   def self.with_temp_zip(glob_path)
-    Dir.mktmpdir do |path|
+    ArchiveUtils.mktmpdir do |path|
       dir = Pathname.new path
       zip = dir.join("#{name}.zip")
       ArchiveUtils.create_zip zip, Dir.glob(glob_path)

--- a/test/models/exam_version_test.rb
+++ b/test/models/exam_version_test.rb
@@ -61,7 +61,7 @@ class ExamVersionTest < ActiveSupport::TestCase
 
   test 'cs2500 is the same when exported and reimported' do
     ev = build(:exam_version, :cs2500_v1)
-    Dir.mktmpdir do |path|
+    ArchiveUtils.mktmpdir do |path|
       ev.export_all(path)
       UploadTestHelper.with_temp_zip(Pathname.new(path).join('**')) do |zip|
         up = Upload.new(Rack::Test::UploadedFile.new(zip))


### PR DESCRIPTION
Running `rails db:populate` on macOS 10.15.6 errors with:
```
rails aborted!
ArchiveUtils::FileReadError: Could not successfully read zip /var/folders/cy/qfxdzkvd32dbyn4r7n049qlw0000gn/T/UploadTestHelper20200909-48322-5nc3cu.zip:
 Could not extract /var/folders/cy/qfxdzkvd32dbyn4r7n049qlw0000gn/T/UploadTestHelper20200909-48322-5nc3cu.zip to /var/folders/cy/qfxdzkvd32dbyn4r7n049qlw0000gn/T/d20200909-48322-7gxekv: files/ does not stay within the extraction directory
/Users/tmazeika/Development/hourglass/lib/archive_utils.rb:621:in `rescue in helper_extract'
...
```
Setting a breakpoint at `lib/archive_utils.rb:578` is where it's rescuing as false. At that point, `safe_realdir(out)` evaluates to `/private/var/folders/cy/...`. I think the issue is that `Dir.mktmpdir` is returning the path without the `/private` part prepended, but calling `File.realdirpath` returns the path with `/private`, which I can only imagine being a macOS-ism, but I can't find anything online about it. This pull request fixes the issue, but I'm not sure of the implications.
