### PR TITLE
Add UI to sync exams to Bottlenose

### DIFF
--- a/app/graphql/mutations/sync_exam_to_bottlenose.rb
+++ b/app/graphql/mutations/sync_exam_to_bottlenose.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Mutations
+  # Mutation to synchronize exam grades with Bottlenose course
+  class SyncExamToBottlenose < BaseMutation
+    argument :exam_id, ID, required: true, loads: Types::ExamType
+
+    field :exam, Types::ExamType, null: false
+
+    def authorized?(exam:)
+      return true if ProfessorCourseRegistration.find_by(
+        user: context[:current_user],
+        course: exam.course,
+      )
+
+      raise GraphQL::ExecutionError, 'You do not have permission.'
+    end
+
+    def resolve(exam:)
+      context[:bottlenose_api].create_exam(exam)
+      { exam: exam }
+    rescue Bottlenose::UnauthorizedError => e
+      raise GraphQL::ExecutionError, e.message
+    rescue Bottlenose::ApiError => e
+      raise GraphQL::ExecutionError, e.message
+    rescue Bottlenose::ConnectionFailed => e
+      raise GraphQL::ExecutionError, e.message
+    end
+  end
+end

--- a/app/graphql/types/exam_type.rb
+++ b/app/graphql/types/exam_type.rb
@@ -14,7 +14,10 @@ module Types
     field :duration, Integer, null: false
     field :start_time, GraphQL::Types::ISO8601DateTime, null: false
     field :end_time, GraphQL::Types::ISO8601DateTime, null: false
-    field :graded, Boolean, null: false
+
+    field :graded, Boolean, null: false do
+      guard Guards::PROFESSORS
+    end
 
     field :course, Types::CourseType, null: false do
       guard Guards::PROFESSORS

--- a/app/graphql/types/exam_type.rb
+++ b/app/graphql/types/exam_type.rb
@@ -14,6 +14,7 @@ module Types
     field :duration, Integer, null: false
     field :start_time, GraphQL::Types::ISO8601DateTime, null: false
     field :end_time, GraphQL::Types::ISO8601DateTime, null: false
+    field :graded, Boolean, null: false
 
     field :course, Types::CourseType, null: false do
       guard Guards::PROFESSORS

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -25,6 +25,7 @@ module Types
     field :update_exam_version, mutation: Mutations::UpdateExamVersion
     field :create_exam_version, mutation: Mutations::CreateExamVersion
     field :sync_course_to_bottlenose, mutation: Mutations::SyncCourseToBottlenose
+    field :sync_exam_to_bottlenose, mutation: Mutations::SyncExamToBottlenose
     field :update_student_seating, mutation: Mutations::UpdateStudentSeating
     field :update_staff_seating, mutation: Mutations::UpdateStaffSeating
     field :update_exam_rooms, mutation: Mutations::UpdateExamRooms

--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -36,6 +36,10 @@ class Exam < ApplicationRecord
   validate :end_after_start
   validate :duration_valid
 
+  def graded
+    finalized? && grading_locks.incomplete.none?
+  end
+
   def duration
     self[:duration].seconds
   end


### PR DESCRIPTION
- Creates a new React component `SyncExamToBottlenoseButton`.
- Creates a new method `graded` on Exam; checks that the exam is finalized and that there's no incomplete grading locks.
- Creates a `SyncExamToBottlenose` GraphQL mutation.

Preview:
<img width="1295" alt="Screen Shot 2020-09-17 at 2 37 27 PM" src="https://user-images.githubusercontent.com/5958957/93531460-44a86880-f90d-11ea-8ad4-7c18e78ed145.png">

@blerner suggested:
> ...move the green button far to the right, so that they're not easily confusable with each other