### PR TITLE
Do not sync course registrations on login

### DIFF
--- a/lib/bottlenose.rb
+++ b/lib/bottlenose.rb
@@ -19,7 +19,6 @@ module Bottlenose
           hg_course.last_sync = DateTime.now
           hg_course.active = true
           hg_course.save!
-          sync_course_regs(hg_course)
         end
       end
     end


### PR DESCRIPTION
This may be convenient, but became a performance issue.
Registrations can still be synced via the red `Sync` button for the course.