### PR TITLE
Add comma to error 500 message

### DIFF
--- a/public/500.html
+++ b/public/500.html
@@ -60,7 +60,7 @@
     <div>
       <h1>We're sorry, but something went wrong.</h1>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <p>If you are the application owner, check the logs for more information.</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
A comma needs to be added between the introductory clause and the main clause. See part 2 [here](https://owl.purdue.edu/owl/general_writing/punctuation/commas/extended_rules_for_commas.html).