### PR TITLE
Fix readonly code marks being *too* readonly

### DIFF
--- a/app/javascript/components/workflows/professor/exams/new/editor/body-items/Code.tsx
+++ b/app/javascript/components/workflows/professor/exams/new/editor/body-items/Code.tsx
@@ -245,6 +245,7 @@ const EditCodeAnswerValues: React.FC<{
                 curRange: { from: cursor, to: cursor },
               });
               removeAllMarks(instance);
+              setAnswerMarks([]);
               debouncedOnChangeValue({ text: answerText, marks: [] });
             }}
           >

--- a/app/javascript/components/workflows/student/exams/show/components/ExamCodeBox.tsx
+++ b/app/javascript/components/workflows/student/exams/show/components/ExamCodeBox.tsx
@@ -44,6 +44,10 @@ export function removeMarks(cm: CM.Editor, marks: MarkDescription[]): void {
   });
 }
 
+export function removeAllMarks(cm: CM.Editor): void {
+  cm.getAllMarks().filter((m) => m.className === 'readOnly').map((m) => m.clear());
+}
+
 export function marksToDescs(marks: CM.TextMarker[]): MarkDescription[] {
   return marks.filter((m) => m.className === 'readOnly').map((m) => {
     const { inclusiveLeft, inclusiveRight } = m;
@@ -128,11 +132,7 @@ export const Editor: React.FC<EditorProps> = (props) => {
     if (instance) {
       doSave = false;
       const curCursor = instance.getCursor();
-      instance.getAllMarks().forEach((m) => {
-        if (m.className === 'readOnly') {
-          m.clear();
-        }
-      });
+      removeAllMarks(instance);
       if (instance.getValue() !== value) { instance.setValue(value); }
       applyMarks(instance, markDescriptions);
       instance.setCursor(curCursor.line, curCursor.ch, {


### PR DESCRIPTION
I think this fixes the three root causes of being unable to unmark a region of code as readonly:

- the debounce interval for code editors was 10sec, as opposed to the 1sec everywhere else
- the remove all marks method didn't actually remove all readOnly marks, but rather only the ones in the value.marks array
- because of debouncing, value.marks wasn't updated very frequently, so the mark wouldn't be found when clicking the unlock button

This code:
- shortens the debounce interval
- fixes the behavior of removeAllMarks
- moves the answerMarks array into a stateful variable that can be updated when the data changes from an input, _or_ programmatically within event handlers