### PR TITLE
Fixes #356.

### DIFF
--- a/app/packs/components/workflows/grading/UseRubrics.tsx
+++ b/app/packs/components/workflows/grading/UseRubrics.tsx
@@ -92,10 +92,7 @@ const ShowPreset: React.FC<{
   const VariantIcon = iconForPoints(points);
   return (
     <Alert variant={variant} className="p-0 preset">
-      <Tooltip
-        showTooltip
-        message="Click to apply this message"
-      >
+      <Tooltip message="Click to apply this message">
         <Button
           disabled={loading}
           variant={variant}

--- a/app/packs/components/workflows/grading/index.tsx
+++ b/app/packs/components/workflows/grading/index.tsx
@@ -1338,7 +1338,7 @@ const Grade: React.FC<{
               drop="right"
             >
               <Tooltip
-                showTooltip={nextExamLoading || anyUncommentedItems}
+                showTooltip={(nextExamLoading || anyUncommentedItems) ? 'onHover' : 'never'}
                 message={nextExamLoading
                   ? 'Please wait; still loading...'
                   : 'Some items have no comments; please grade them'}

--- a/app/packs/components/workflows/professor/exams/admin.tsx
+++ b/app/packs/components/workflows/professor/exams/admin.tsx
@@ -1021,7 +1021,7 @@ const PublishGradesButton: React.FC<{
   const reason = loading ? 'Loading...' : 'Not all exams are graded yet';
   return (
     <Tooltip
-      showTooltip={disabled}
+      showTooltip={disabled ? 'onHover' : 'never'}
       message={reason}
       placement="bottom"
     >

--- a/app/packs/components/workflows/student/exams/show/components/Tooltip.tsx
+++ b/app/packs/components/workflows/student/exams/show/components/Tooltip.tsx
@@ -1,42 +1,66 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Tooltip as BSTooltip,
   OverlayTrigger,
   OverlayTriggerProps,
 } from 'react-bootstrap';
+import { OverlayInjectedProps } from 'react-bootstrap/esm/Overlay';
 
 export interface TooltipProps {
   message: string;
   className?: string;
-  showTooltip?: boolean;
-  defaultShow?: boolean;
+  showTooltip?: 'always' | 'never' | 'onHover';
   placement?: OverlayTriggerProps['placement'];
   children: React.ReactElement;
 }
+
+// NOTE(Ben, 5/30): This hackaround seems to be needed to fix
+// https://github.com/react-bootstrap/react-bootstrap/issues/6010
+// When we upgrade react-bootstrap to something greater than 2.4.1,
+// we should get this fix automatically, and can go back to a simpler
+// OverlayTrigger/BSTooltip without needing this workaround.
+const UpdatingTooltip = React.forwardRef<HTMLDivElement, OverlayInjectedProps>(({
+  popper,
+  children,
+  style,
+  arrowProps,
+  className,
+  placement,
+  ...props
+}, ref) => (
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  <span {...props} style={{ ...style, position: 'absolute', transform: undefined }}>
+    <BSTooltip
+      id={null}
+      ref={ref}
+      placement={placement}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+      style={{ ...style, position: 'relative' }}
+      className={className}
+      arrowProps={arrowProps}
+    >
+      {children}
+    </BSTooltip>
+  </span>
+));
 
 const Tooltip: React.FC<TooltipProps> = (props) => {
   const {
     message,
     className,
-    showTooltip = true,
-    defaultShow,
+    showTooltip = 'onHover',
     placement = 'bottom',
     children,
   } = props;
-  const tooltip = showTooltip
-    ? (
-      <BSTooltip
-        className={className}
-        id={null}
-      >
-        {message}
-      </BSTooltip>
-    )
-    : ((): JSX.Element => <span />);
+  const [show, setShow] = useState(showTooltip === 'always');
   return (
     <OverlayTrigger
-      show={defaultShow}
-      overlay={tooltip}
+      show={show}
+      onToggle={(nextShow) => {
+        setShow((showTooltip !== 'never') && nextShow);
+      }}
+      overlay={<UpdatingTooltip className={className}>{message}</UpdatingTooltip>}
       placement={placement}
     >
       {children}

--- a/app/packs/components/workflows/student/exams/show/components/TooltipButton.tsx
+++ b/app/packs/components/workflows/student/exams/show/components/TooltipButton.tsx
@@ -31,7 +31,7 @@ const TooltipButton: React.FC<TooltipButtonProps> = (props) => {
   } = props;
   return (
     <Tooltip
-      showTooltip={disabled || !!enabledMessage}
+      showTooltip={(disabled || !!enabledMessage) ? 'onHover' : 'never'}
       message={disabled ? disabledMessage : enabledMessage}
       placement={placement}
     >

--- a/app/packs/components/workflows/student/exams/show/components/navbar/NavAccordionItem.tsx
+++ b/app/packs/components/workflows/student/exams/show/components/navbar/NavAccordionItem.tsx
@@ -42,8 +42,7 @@ const NavAccordionItem: React.FC<NavAccordionItemProps> = (props) => {
   const toggle = (
     <Tooltip
       className={tooltipClassname}
-      defaultShow={(showTooltip === 'always') || undefined}
-      showTooltip={showTooltip !== 'never'}
+      showTooltip={showTooltip}
       message={tooltipMessage}
       placement={tooltipPlacement}
     >


### PR DESCRIPTION
The underlying problem seems to be that the parent element of the tooltip isn't positioned absolutely, so popper can't measure its position correctly and so it flickers to the origin and then into its correct position.

Additionally, I've cleaned up the showTooltip/defaultShow properties into a single showTooltip property: there were only three values, but four boolean combinations, and the names weren't making much sense...