### PR TITLE
Implementation of per-exam-version start/end/duration, fixes #416.

### DIFF
--- a/app/graphql/mutations/destroy_exam_version.rb
+++ b/app/graphql/mutations/destroy_exam_version.rb
@@ -6,6 +6,7 @@ module Mutations
     argument :exam_version_id, ID, required: true, loads: Types::ExamVersionType
 
     field :deletedId, ID, null: false
+    field :exam, Types::ExamType, null: false
 
     def authorized?(exam_version:)
       return true if exam_version.course.user_is_professor?(context[:current_user])
@@ -17,10 +18,14 @@ module Mutations
       check_final(exam_version)
       check_started(exam_version)
 
+      exam = exam_version.exam
       destroyed = exam_version.destroy
       raise GraphQL::ExecutionError, exam_version.errors.full_messages.to_sentence unless destroyed
 
-      { deletedId: HourglassSchema.id_from_object(exam_version, Types::ExamVersionType, context) }
+      { 
+        deletedId: HourglassSchema.id_from_object(exam_version, Types::ExamVersionType, context) ,
+        exam: exam
+      }
     end
 
     private

--- a/app/graphql/mutations/update_version_timing.rb
+++ b/app/graphql/mutations/update_version_timing.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Mutations
+  # Mutation to up date an exam's administrative details
+  class UpdateVersionTiming < BaseMutation
+    argument :exam_version_id, ID, required: true, loads: Types::ExamVersionType
+    argument :duration, Integer, required: false
+    argument :start_time, GraphQL::Types::ISO8601DateTime, required: false
+    argument :end_time, GraphQL::Types::ISO8601DateTime, required: false
+
+    field :exam_version, Types::ExamVersionType, null: false
+    field :exam, Types::ExamType, null: false
+
+    def authorized?(exam_version:, **_args)
+      return true if exam_version.course.user_is_professor?(context[:current_user])
+
+      raise GraphQL::ExecutionError, 'You do not have permission.'
+    end
+
+    def resolve(exam_version:, **args)
+      updated = exam_version.update(args)
+      raise GraphQL::ExecutionError, exam_version.errors.full_messages.to_sentence unless updated
+
+      cache_authorization!(exam_version.exam, exam_version.course)
+      { exam_version: exam_version, exam: exam_version.exam }
+    end
+  end
+end

--- a/app/graphql/types/exam_checklist_type.rb
+++ b/app/graphql/types/exam_checklist_type.rb
@@ -3,6 +3,7 @@
 module Types
   class ExamChecklistType < Types::BaseObject
     field :rooms, Types::ExamChecklistSectionType, null: false
+    field :timing, Types::ExamChecklistSectionType, null: false
     field :staff, Types::ExamChecklistSectionType, null: false
     field :seating, Types::ExamChecklistSectionType, null: false
     field :versions, Types::ExamChecklistSectionType, null: false

--- a/app/graphql/types/exam_version_type.rb
+++ b/app/graphql/types/exam_version_type.rb
@@ -46,6 +46,9 @@ module Types
     end
 
     field :policies, [Types::LockdownPolicyType], null: false
+    field :duration, Integer, null: true
+    field :start_time, GraphQL::Types::ISO8601DateTime, null: true
+    field :end_time, GraphQL::Types::ISO8601DateTime, null: true
 
     field :students, [Types::UserType], null: false do
       guard Guards::PROFESSORS

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -26,6 +26,7 @@ module Types
     field :update_staff_seating, mutation: Mutations::UpdateStaffSeating
     field :update_exam_rooms, mutation: Mutations::UpdateExamRooms
     field :update_version_registrations, mutation: Mutations::UpdateVersionRegistrations
+    field :update_version_timing, mutation: Mutations::UpdateVersionTiming
     field :destroy_accommodation, mutation: Mutations::DestroyAccommodation
     field :update_accommodation, mutation: Mutations::UpdateAccommodation
     field :create_accommodation, mutation: Mutations::CreateAccommodation

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -84,9 +84,7 @@ class Registration < ApplicationRecord
   end
 
   def accommodated_end_time
-    accommodated_start_time +
-      (exam_version.effective_end_time - exam_version.effective_start_time) +
-      accommodated_extra_duration
+    accommodated_start_time + exam_version.effective_time_window + accommodated_extra_duration
   end
 
   # End time plus any applicable extensions

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -67,21 +67,26 @@ class Registration < ApplicationRecord
   # my-start >= my-exam-start
   # my-end <= my-exam-end
   # my-end <= my-start + my-duration
+  #
+  # NOTE: If the exam version itself defines a start time/end time/duration,
+  # those override the exam-specified times.
 
   def accommodated_start_time
-    accommodation&.new_start_time || exam.start_time
+    accommodation&.new_start_time || exam_version.effective_start_time
   end
 
   def accommodated_duration
-    exam.duration * (accommodation&.factor || 1)
+    exam_version.effective_duration * (accommodation&.factor || 1)
   end
 
   def accommodated_extra_duration
-    accommodated_duration - exam.duration
+    accommodated_duration - exam_version.effective_duration
   end
 
   def accommodated_end_time
-    accommodated_start_time + (exam.end_time - exam.start_time) + accommodated_extra_duration
+    accommodated_start_time +
+      (exam_version.effective_end_time - exam_version.effective_start_time) +
+      accommodated_extra_duration
   end
 
   # End time plus any applicable extensions

--- a/app/packs/components/workflows/professor/exams/admin.tsx
+++ b/app/packs/components/workflows/professor/exams/admin.tsx
@@ -28,8 +28,6 @@ import {
   Tab,
   Nav,
   Container,
-  ToggleButtonGroup,
-  ToggleButton,
 } from 'react-bootstrap';
 import {
   FaChevronUp,
@@ -47,7 +45,6 @@ import { DateTime } from 'luxon';
 import Tooltip from '@student/exams/show/components/Tooltip';
 import EditExamRooms from '@professor/exams/rooms';
 import EditExamVersionTiming from '@professor/exams/versionTiming/';
-import { ExamTimesViewer, ExamTimesEditor } from './versionTiming/editors';
 import ManageAccommodations from '@professor/exams/accommodations';
 import AssignSeating from '@hourglass/common/student-dnd';
 import AllocateVersions from '@professor/exams/allocate-versions';
@@ -58,12 +55,13 @@ import { BsPencilSquare, BsFillQuestionCircleFill } from 'react-icons/bs';
 import { GiOpenBook } from 'react-icons/gi';
 import DocumentTitle from '@hourglass/common/documentTitle';
 import { policyToString } from '@professor/exams/new/editor/Policies';
+import { uploadFile } from '@hourglass/common/types/api';
 import {
   graphql,
   useFragment,
   useLazyLoadQuery,
 } from 'react-relay';
-import { uploadFile } from '@hourglass/common/types/api';
+import { ExamTimesViewer, ExamTimesEditor } from './versionTiming/editors';
 import './dnd.scss';
 import './admin.scss';
 
@@ -487,7 +485,6 @@ const ExamInfoViewer: React.FC<{
   );
 };
 
-
 export const ExamInfoEditor: React.FC<{
   disabled: boolean;
   onSubmit: (info: ExamUpdateInfo) => void;
@@ -565,8 +562,6 @@ export const ExamInfoEditor: React.FC<{
     </Card>
   );
 };
-
-
 
 const VersionInfo: React.FC<{
   exam: admin_versionInfo$key;
@@ -762,8 +757,6 @@ const ShowVersion: React.FC<{
   } else if (loading) {
     disabledDeleteMessage = 'Please wait...';
   }
-  const startTime = res.startTime && DateTime.fromISO(res.startTime);
-  const endTime = res.startTime && DateTime.fromISO(res.endTime);
   return (
     <>
       <h3 className="flex-grow-1">

--- a/app/packs/components/workflows/professor/exams/admin.tsx
+++ b/app/packs/components/workflows/professor/exams/admin.tsx
@@ -717,6 +717,26 @@ const ShowVersion: React.FC<{
     mutation adminDestroyVersionMutation($input: DestroyExamVersionInput!) {
       destroyExamVersion(input: $input) {
         deletedId
+        exam {
+          checklist {
+            timing {
+              reason
+              status
+            }
+            staff {
+              reason
+              status
+            }
+            seating {
+              reason
+              status
+            }
+            versions {
+              reason
+              status
+            }    
+          }
+        }
       }
     }
     `,

--- a/app/packs/components/workflows/professor/exams/new/DateTimePicker.tsx
+++ b/app/packs/components/workflows/professor/exams/new/DateTimePicker.tsx
@@ -19,6 +19,7 @@ interface DateTimeProps {
   value?: DateTime;
   minValue?: DateTime;
   maxValue?: DateTime;
+  unsetPlaceholder?: string;
   onChange: (newVal: DateTime) => void;
   nullable?: boolean;
 }
@@ -52,6 +53,7 @@ const DateTimePicker: React.FC<DateTimeProps> = (props) => {
     minValue,
     maxValue,
     onChange,
+    unsetPlaceholder = 'Not set.',
     nullable = false,
   } = props;
   const timeZone = value?.zoneName ?? 'UTC';
@@ -63,7 +65,7 @@ const DateTimePicker: React.FC<DateTimeProps> = (props) => {
           ...DateTime.DATETIME_SHORT,
           timeZone,
           timeZoneName: 'short',
-        }) ?? 'Not set.'}
+        }) ?? unsetPlaceholder}
       />
       {value && nullable && (
         <InputGroup.Append>

--- a/app/packs/components/workflows/professor/exams/versionTiming/editors.tsx
+++ b/app/packs/components/workflows/professor/exams/versionTiming/editors.tsx
@@ -153,4 +153,4 @@ export const ExamTimesEditor: React.FC<{
       </Form.Group>
     </>
   );
-}
+};

--- a/app/packs/components/workflows/professor/exams/versionTiming/editors.tsx
+++ b/app/packs/components/workflows/professor/exams/versionTiming/editors.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+import {
+  Form,
+  Row,
+  Col,
+} from 'react-bootstrap';
+import { DateTime } from 'luxon';
+import { GrLink, GrUnlink } from 'react-icons/gr';
+import { BsArrow90DegLeft } from 'react-icons/bs';
+import Icon from '@student/exams/show/components/Icon';
+import TooltipButton from '@student/exams/show/components/TooltipButton';
+import DateTimePicker from '@professor/exams/new/DateTimePicker';
+import ReadableDate from '@hourglass/common/ReadableDate';
+import { NumericInput } from '@hourglass/common/NumericInput';
+
+export const ExamTimesViewer: React.FC<{
+  startTime?: DateTime,
+  endTime?: DateTime,
+  duration?: number,
+  placeholder?: string,
+}> = (props) => {
+  const {
+    startTime,
+    endTime,
+    duration,
+    placeholder,
+  } = props;
+  return (
+    <>
+      <Row className="align-items-center">
+        <Form.Label column sm={2}>Starts:</Form.Label>
+        {startTime ? <ReadableDate value={startTime} showTime /> : placeholder}
+      </Row>
+      <Row className="align-items-center">
+        <Form.Label column sm={2}>Ends:</Form.Label>
+        {endTime ? <ReadableDate value={endTime} showTime /> : placeholder}
+      </Row>
+      <Row className="align-items-center">
+        <Form.Label column sm={2}>Duration:</Form.Label>
+        {duration !== null ? `${duration / 60.0} minutes` : placeholder}
+      </Row>
+    </>
+  );
+};
+export const ExamTimesEditor: React.FC<{
+  disabled?: boolean,
+  start: DateTime,
+  setStart: (s: DateTime) => void,
+  end: DateTime,
+  setEnd: (e: DateTime) => void,
+  duration: number | string,
+  setDuration: (d: number | string) => void,
+  unsetPlaceholder?: string,
+}> = (props) => {
+  const {
+    disabled,
+    start, setStart,
+    end, setEnd,
+    duration, setDuration,
+    unsetPlaceholder,
+  } = props;
+  const [linked, setLinked] = useState<boolean>(true);
+  return (
+    <>
+      <Form.Group as={Row} className="mb-3">
+        <Col className="pr-0" sm={2}>
+          <Form.Group as={Row} controlId="examStartTime" className="align-items-center">
+            <Form.Label column>Start time:</Form.Label>
+          </Form.Group>
+          <Form.Group as={Row} controlId="examEndTime" className="align-items-center mb-0">
+            <Form.Label column>End time:</Form.Label>
+          </Form.Group>
+        </Col>
+        <Col className="pr-0">
+          <Form.Group as={Row} controlId="examStartTime" className="align-items-center">
+            <Col>
+              <DateTimePicker
+                disabled={disabled}
+                value={start}
+                maxValue={linked ? undefined : end}
+                onChange={(newVal) => {
+                  if (linked) {
+                    setEnd(newVal.plus(end.diff(start)));
+                    setStart(newVal);
+                  } else {
+                    const curDuration = { minutes: Number(duration) || 0 };
+                    const maxStartTime = end.minus(curDuration);
+                    setStart(newVal <= maxStartTime ? newVal : maxStartTime);
+                  }
+                }}
+                unsetPlaceholder={unsetPlaceholder}
+              />
+            </Col>
+          </Form.Group>
+          <Form.Group as={Row} controlId="examEndTime" className="align-items-center mb-0">
+            <Col>
+              <DateTimePicker
+                disabled={disabled}
+                value={end}
+                minValue={linked ? undefined : start}
+                onChange={(newVal) => {
+                  if (linked) {
+                    setStart(newVal.minus(end.diff(start)));
+                    setEnd(newVal);
+                  } else {
+                    const curDuration = { minutes: Number(duration) || 0 };
+                    const minEndTime = start.plus(curDuration);
+                    setEnd(newVal >= minEndTime ? newVal : minEndTime);
+                  }
+                }}
+                unsetPlaceholder={unsetPlaceholder}
+              />
+            </Col>
+          </Form.Group>
+        </Col>
+        <Col sm="auto" className="pl-0 pr-2 d-flex flex-column justify-content-center">
+          <Icon I={BsArrow90DegLeft} size="1.25em" />
+          <TooltipButton
+            variant="link"
+            disabled={false}
+            className="ml-1 p-0 rotate-45"
+            enabledMessage={linked ? 'Start and end times are linked' : 'Start and end times are independent'}
+            onClick={() => setLinked(!linked)}
+          >
+            <Icon I={linked ? GrLink : GrUnlink} />
+          </TooltipButton>
+          <span style={{ transform: 'scaleY(-1)' }}><Icon I={BsArrow90DegLeft} size="1.25em" /></span>
+        </Col>
+      </Form.Group>
+      <Form.Group as={Row} controlId="examDuration" className="align-items-center my-0">
+        <Form.Label column sm={2}>Duration (minutes):</Form.Label>
+        <Col>
+          <NumericInput
+            disabled={disabled}
+            value={Number(duration) || 0}
+            className="overflow-visible"
+            variant="primary"
+            min={0}
+            max={linked ? undefined : end.diff(start).as('minutes')}
+            onChange={(newVal) => {
+              if (linked) {
+                setDuration(newVal);
+                if (start.plus({ minutes: newVal }) > end) {
+                  setEnd(start.plus({ minutes: newVal }));
+                }
+              } else {
+                const availTime = end.diff(start).as('minutes');
+                setDuration(Math.min(newVal, availTime));
+              }
+            }}
+          />
+        </Col>
+      </Form.Group>
+    </>
+  );
+}

--- a/app/packs/components/workflows/professor/exams/versionTiming/index.tsx
+++ b/app/packs/components/workflows/professor/exams/versionTiming/index.tsx
@@ -1,0 +1,257 @@
+import React, { useContext, useState } from 'react';
+import {
+  Button,
+  Row,
+  Col,
+  Card,
+  ToggleButtonGroup,
+  ToggleButton,
+} from 'react-bootstrap';
+import Icon from '@student/exams/show/components/Icon';
+import { AlertContext } from '@hourglass/common/alerts';
+import { graphql, useFragment } from 'react-relay';
+import { ExamTimesViewer, ExamTimesEditor } from './editors';
+import { useMutationWithDefaults } from '@hourglass/common/helpers';
+
+import { versionTiming$key, versionTiming } from './__generated__/versionTiming.graphql';
+import { versionTimingUpdateMutation } from './__generated__/versionTimingUpdateMutation.graphql';
+import { DateTime } from 'luxon';
+import { BsPencilSquare } from 'react-icons/bs';
+
+const EditExamVersionTiming: React.FC<{
+  examKey: versionTiming$key;
+}> = (props) => {
+  const {
+    examKey,
+  } = props;
+  const res = useFragment(
+    graphql`
+    fragment versionTiming on Exam {
+      id
+      startTime
+      endTime
+      duration
+      examVersions(first: 100) @connection(key: "Exam_examVersions", filters: []) {
+        edges {
+          node {
+            id
+            name
+            startTime
+            endTime
+            duration
+          }
+        }
+      }
+    }
+    `,
+    examKey,
+  );
+  const {
+    startTime,
+    endTime,
+    duration,
+    examVersions
+  } = res;
+  return (
+    <>
+      {examVersions.edges.map((n) => <ExamVersionInfoEditor
+        key={n.node.id}
+        examVersionId={n.node.id}
+        examStart={DateTime.fromISO(startTime)}
+        examEnd={DateTime.fromISO(endTime)}
+        examDuration={duration}
+        version={n.node}
+        />
+      )}
+    </>
+  );
+}
+export default EditExamVersionTiming;
+
+
+const ExamVersionInfoEditor: React.FC<{
+  examVersionId: string,
+  examStart: DateTime,
+  examEnd: DateTime,
+  examDuration: number,
+  version: versionTiming['examVersions']['edges'][number]['node']
+}> = (props) => {
+  const {
+    examVersionId,
+    examStart,
+    examEnd,
+    examDuration,
+    version
+  } = props;
+  const { alert } = useContext(AlertContext);
+  const versionStartTime = version.startTime && DateTime.fromISO(version.startTime);
+  const versionEndTime = version.endTime && DateTime.fromISO(version.endTime);
+  const versionDuration = version.duration;
+  const [showEditor, setShowEditor] = useState<boolean>(false);
+  const [startTime, setStartTime] = useState(versionStartTime || examStart);
+  const [endTime, setEndTime] = useState(versionEndTime || examEnd);
+  const [duration, setDuration] = useState<string | number>(versionDuration ?? examDuration);
+  const [mutate, loading] = useMutationWithDefaults<versionTimingUpdateMutation>(
+    graphql`
+    mutation versionTimingUpdateMutation($input: UpdateVersionTimingInput!, $withRubric: Boolean!) {
+      updateVersionTiming(input: $input) {
+        exam {
+          ...admin_checklist
+        }
+      }
+    }
+    `,
+    {
+      onCompleted: () => {
+        setShowEditor(false);
+        alert({
+          variant: 'success',
+          autohide: true,
+          message: 'Version timing successfully allocated.',
+        });
+      },
+      onError: (err) => {
+        alert({
+          variant: 'danger',
+          title: 'Version timing not set.',
+          message: err.message,
+          copyButton: true,
+        });
+      },
+    },
+  );
+  return (
+    <Row className="mb-2">
+      <Col>
+        <h3>
+          {version.name}
+          {showEditor
+            ? <span className="float-right">
+                <Button
+                  variant="danger"
+                  disabled={loading}
+                  onClick={() => {
+                    mutate({
+                      variables: {
+                        input: {
+                          examVersionId,
+                          duration: null,
+                          startTime: null,
+                          endTime: null
+                        },
+                        withRubric: true
+                      },
+                    });
+                  }}>
+                  Reset
+                </Button>
+                <Button 
+                  variant="secondary" 
+                  disabled={loading}
+                  className="ml-2"
+                  onClick={() => {
+                    setStartTime(versionStartTime || examStart);
+                    setEndTime(versionEndTime || examEnd);
+                    setDuration(versionDuration ?? examDuration)
+                    setShowEditor(false);
+                  }}>
+                  Cancel
+                </Button>
+                <Button 
+                  disabled={loading}
+                  className="ml-2"
+                  onClick={() => {
+                    mutate({
+                      variables: {
+                        input: {
+                          examVersionId,
+                          duration: Number(duration) * 60.0,
+                          startTime: startTime.toISO(),
+                          endTime: endTime.toISO(),
+                        },
+                        withRubric: true
+                      }
+                    });
+                  }}>
+                  Save
+                </Button>
+              </span>
+            : <span className="float-right">
+               <Button onClick={() => setShowEditor(true)}>
+                 <Icon I={BsPencilSquare} />
+                 <span className="ml-2">
+                   Edit
+                 </span>
+               </Button>
+             </span>
+          }
+        </h3>
+        {showEditor
+          ? <ExamTimesEditor
+              start={startTime}
+              setStart={setStartTime}
+              end={endTime}
+              setEnd={setEndTime}
+              duration={duration}
+              setDuration={setDuration}
+              unsetPlaceholder={'Same as exam'}
+          />
+          : <ExamTimesViewer
+            startTime={versionStartTime}
+            endTime={versionEndTime}
+            duration={versionDuration}
+            placeholder={'Same as exam'}
+          />
+        }
+      </Col>
+    </Row>
+  );
+};
+
+const ExamVersionInfoEditorOld: React.FC<{
+  onClickEdit: () => void;
+  startTime: DateTime;
+  endTime: DateTime;
+  duration: number;
+}> = (props) => {
+  const {
+    onClickEdit,
+    startTime,
+    endTime,
+    duration,
+  } = props;
+  const [customTime, useCustomTime] = useState(
+    startTime !== null || endTime !== null || duration !== null
+  );
+  return (
+    <Card>
+      <Card.Body>
+        <Row>
+          <Col>
+            <span className="mr-3">Time availability:</span>
+            <ToggleButtonGroup
+              name="availability"
+              size='sm'
+              type="radio"
+              value={customTime ? 'yes' : 'no'}
+              onChange={(newVal: 'yes' | 'no') => useCustomTime(newVal === 'yes')}
+            >
+              <ToggleButton
+                variant='outline-primary'
+                value="no"
+              >
+                Same as exam
+              </ToggleButton>
+              <ToggleButton
+                variant='outline-primary'
+                value="yes"
+              >
+                Customized
+              </ToggleButton>
+            </ToggleButtonGroup>
+          </Col>
+        </Row>
+      </Card.Body>
+    </Card>
+  );
+};

--- a/app/packs/components/workflows/professor/exams/versionTiming/index.tsx
+++ b/app/packs/components/workflows/professor/exams/versionTiming/index.tsx
@@ -3,20 +3,17 @@ import {
   Button,
   Row,
   Col,
-  Card,
-  ToggleButtonGroup,
-  ToggleButton,
 } from 'react-bootstrap';
+import { graphql, useFragment } from 'react-relay';
+import { DateTime } from 'luxon';
+import { BsPencilSquare } from 'react-icons/bs';
 import Icon from '@student/exams/show/components/Icon';
 import { AlertContext } from '@hourglass/common/alerts';
-import { graphql, useFragment } from 'react-relay';
-import { ExamTimesViewer, ExamTimesEditor } from './editors';
 import { useMutationWithDefaults } from '@hourglass/common/helpers';
+import { ExamTimesViewer, ExamTimesEditor } from './editors';
 
 import { versionTiming$key, versionTiming } from './__generated__/versionTiming.graphql';
 import { versionTimingUpdateMutation } from './__generated__/versionTimingUpdateMutation.graphql';
-import { DateTime } from 'luxon';
-import { BsPencilSquare } from 'react-icons/bs';
 
 const EditExamVersionTiming: React.FC<{
   examKey: versionTiming$key;
@@ -50,24 +47,24 @@ const EditExamVersionTiming: React.FC<{
     startTime,
     endTime,
     duration,
-    examVersions
+    examVersions,
   } = res;
   return (
     <>
-      {examVersions.edges.map((n) => <ExamVersionInfoEditor
-        key={n.node.id}
-        examVersionId={n.node.id}
-        examStart={DateTime.fromISO(startTime)}
-        examEnd={DateTime.fromISO(endTime)}
-        examDuration={duration}
-        version={n.node}
+      {examVersions.edges.map((n) => (
+        <ExamVersionInfoEditor
+          key={n.node.id}
+          examVersionId={n.node.id}
+          examStart={DateTime.fromISO(startTime)}
+          examEnd={DateTime.fromISO(endTime)}
+          examDuration={duration}
+          version={n.node}
         />
-      )}
+      ))}
     </>
   );
-}
+};
 export default EditExamVersionTiming;
-
 
 const ExamVersionInfoEditor: React.FC<{
   examVersionId: string,
@@ -81,7 +78,7 @@ const ExamVersionInfoEditor: React.FC<{
     examStart,
     examEnd,
     examDuration,
-    version
+    version,
   } = props;
   const { alert } = useContext(AlertContext);
   const versionStartTime = version.startTime && DateTime.fromISO(version.startTime);
@@ -126,7 +123,8 @@ const ExamVersionInfoEditor: React.FC<{
         <h3>
           {version.name}
           {showEditor
-            ? <span className="float-right">
+            ? (
+              <span className="float-right">
                 <Button
                   variant="danger"
                   disabled={loading}
@@ -137,27 +135,29 @@ const ExamVersionInfoEditor: React.FC<{
                           examVersionId,
                           duration: null,
                           startTime: null,
-                          endTime: null
+                          endTime: null,
                         },
-                        withRubric: true
+                        withRubric: true,
                       },
                     });
-                  }}>
+                  }}
+                >
                   Reset
                 </Button>
-                <Button 
-                  variant="secondary" 
+                <Button
+                  variant="secondary"
                   disabled={loading}
                   className="ml-2"
                   onClick={() => {
                     setStartTime(versionStartTime || examStart);
                     setEndTime(versionEndTime || examEnd);
-                    setDuration(versionDuration ?? examDuration)
+                    setDuration(versionDuration ?? examDuration);
                     setShowEditor(false);
-                  }}>
+                  }}
+                >
                   Cancel
                 </Button>
-                <Button 
+                <Button
                   disabled={loading}
                   className="ml-2"
                   onClick={() => {
@@ -169,89 +169,47 @@ const ExamVersionInfoEditor: React.FC<{
                           startTime: startTime.toISO(),
                           endTime: endTime.toISO(),
                         },
-                        withRubric: true
-                      }
+                        withRubric: true,
+                      },
                     });
-                  }}>
+                  }}
+                >
                   Save
                 </Button>
               </span>
-            : <span className="float-right">
-               <Button onClick={() => setShowEditor(true)}>
-                 <Icon I={BsPencilSquare} />
-                 <span className="ml-2">
-                   Edit
-                 </span>
-               </Button>
-             </span>
-          }
+            )
+            : (
+              <span className="float-right">
+                <Button onClick={() => setShowEditor(true)}>
+                  <Icon I={BsPencilSquare} />
+                  <span className="ml-2">
+                    Edit
+                  </span>
+                </Button>
+              </span>
+            )}
         </h3>
         {showEditor
-          ? <ExamTimesEditor
+          ? (
+            <ExamTimesEditor
               start={startTime}
               setStart={setStartTime}
               end={endTime}
               setEnd={setEndTime}
               duration={duration}
               setDuration={setDuration}
-              unsetPlaceholder={'Same as exam'}
-          />
-          : <ExamTimesViewer
-            startTime={versionStartTime}
-            endTime={versionEndTime}
-            duration={versionDuration}
-            placeholder={'Same as exam'}
-          />
-        }
+              unsetPlaceholder="Same as exam"
+            />
+          )
+          : (
+            <ExamTimesViewer
+              startTime={versionStartTime}
+              endTime={versionEndTime}
+              duration={versionDuration}
+              placeholder="Same as exam"
+            />
+          )}
       </Col>
     </Row>
-  );
-};
-
-const ExamVersionInfoEditorOld: React.FC<{
-  onClickEdit: () => void;
-  startTime: DateTime;
-  endTime: DateTime;
-  duration: number;
-}> = (props) => {
-  const {
-    onClickEdit,
-    startTime,
-    endTime,
-    duration,
-  } = props;
-  const [customTime, useCustomTime] = useState(
-    startTime !== null || endTime !== null || duration !== null
-  );
-  return (
-    <Card>
-      <Card.Body>
-        <Row>
-          <Col>
-            <span className="mr-3">Time availability:</span>
-            <ToggleButtonGroup
-              name="availability"
-              size='sm'
-              type="radio"
-              value={customTime ? 'yes' : 'no'}
-              onChange={(newVal: 'yes' | 'no') => useCustomTime(newVal === 'yes')}
-            >
-              <ToggleButton
-                variant='outline-primary'
-                value="no"
-              >
-                Same as exam
-              </ToggleButton>
-              <ToggleButton
-                variant='outline-primary'
-                value="yes"
-              >
-                Customized
-              </ToggleButton>
-            </ToggleButtonGroup>
-          </Col>
-        </Row>
-      </Card.Body>
-    </Card>
   );
 };

--- a/db/migrate/20220911215356_add_times_to_exam_versions.rb
+++ b/db/migrate/20220911215356_add_times_to_exam_versions.rb
@@ -1,0 +1,7 @@
+class AddTimesToExamVersions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :exam_versions, :start_time, :datetime, null: true
+    add_column :exam_versions, :end_time, :datetime, null: true
+    add_column :exam_versions, :duration, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_11_223649) do
+ActiveRecord::Schema.define(version: 2022_09_11_215356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,9 @@ ActiveRecord::Schema.define(version: 2021_09_11_223649) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "instructions", default: "", null: false
     t.string "policies", default: "", null: false
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.integer "duration"
     t.index ["exam_id"], name: "index_exam_versions_on_exam_id"
   end
 

--- a/test/models/exam_version_test.rb
+++ b/test/models/exam_version_test.rb
@@ -130,4 +130,26 @@ class ExamVersionTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test 'exam versions can have alternate times' do
+    ev = create(:exam_version, :blank)
+    exam = ev.exam
+    assert_nil ev.start_time
+    assert_nil ev.end_time
+    assert_nil ev.duration
+    assert_equal exam.start_time, ev.effective_start_time
+    assert_equal exam.end_time, ev.effective_end_time
+    assert_equal exam.duration, ev.effective_duration
+
+    now = DateTime.now
+    ev.start_time = now + 1.hour
+    ev.end_time = now + 5.hours
+    ev.duration = 300
+    assert_not_equal exam.start_time, ev.effective_start_time
+    assert_not_equal exam.end_time, ev.effective_end_time
+    assert_not_equal exam.duration, ev.effective_duration
+    assert_equal now + 1.hour, ev.effective_start_time
+    assert_equal now + 5.hours, ev.effective_end_time
+    assert_equal 300, ev.effective_duration
+  end
 end


### PR DESCRIPTION
Technically, we could support the exam version only specifying a custom start or end or duration, rather than all three.  But for validation and for UI consistency, it's easier to specify all three at once.  Since we never refer to an exam's start/end/duration directly, but rather only through a registration's accommodated_start/end/duration, we simply interpose in those methods and refer to the exam_version's "effective" start/end/duration, which fall back to the exam's start/end/duration if they're not explicitly specified.