### PR TITLE
Fix stats performance

### DIFF
--- a/app/graphql/types/body_item_type.rb
+++ b/app/graphql/types/body_item_type.rb
@@ -29,5 +29,8 @@ module Types
     field :root_rubric, Types::RubricType, null: false do
       guard Guards::ALL_STAFF
     end
+    def root_rubric
+      AssociationLoader.for(BodyItem, :rubrics, merge: -> { body_item_root_rubrics }).load(object).then(&:first)
+    end
   end
 end

--- a/app/graphql/types/grading_comment_type.rb
+++ b/app/graphql/types/grading_comment_type.rb
@@ -26,6 +26,5 @@ module Types
     field :message, String, null: false
     field :points, Float, null: false
     field :creator, Types::UserType, null: false
-    field :preset_comment, Types::PresetCommentType, null: true
   end
 end

--- a/app/graphql/types/part_type.rb
+++ b/app/graphql/types/part_type.rb
@@ -45,5 +45,8 @@ module Types
     field :root_rubric, Types::RubricType, null: false do
       guard Guards::ALL_STAFF
     end
+    def root_rubric
+      AssociationLoader.for(Part, :rubrics, merge: -> { part_root_rubrics }).load(object).then(&:first)
+    end
   end
 end

--- a/app/graphql/types/question_type.rb
+++ b/app/graphql/types/question_type.rb
@@ -45,5 +45,8 @@ module Types
     field :root_rubric, Types::RubricType, null: false do
       guard Guards::ALL_STAFF
     end
+    def root_rubric
+      AssociationLoader.for(Question, :rubrics, merge: -> { question_root_rubrics }).load(object).then(&:first)
+    end
   end
 end

--- a/app/graphql/types/registration_type.rb
+++ b/app/graphql/types/registration_type.rb
@@ -125,6 +125,23 @@ module Types
       end
     end
 
+    field :all_grading_comments, [Types::GradingCommentType], null: false
+    def all_grading_comments
+      if ALL_STAFF_OR_PUBLISHED.call(self, nil, context)
+        AssociationLoader.for(Registration, :grading_comments, includes: [
+          :creator, 
+          :question,
+          :part,
+          :body_item,
+          preset_comment: :rubric_preset,
+          registration: :user,
+        ]).load(object)
+      else
+        nil
+      end
+    end
+
+
     field :anomalous, Boolean, null: false
     def anomalous
       object.anomalous?

--- a/app/graphql/types/registration_type.rb
+++ b/app/graphql/types/registration_type.rb
@@ -119,7 +119,12 @@ module Types
     field :grading_comments, Types::GradingCommentType.connection_type, null: true
     def grading_comments
       if ALL_STAFF_OR_PUBLISHED.call(self, nil, context)
-        AssociationLoader.for(Registration, :grading_comments).load(object)
+        AssociationLoader.for(Registration, :grading_comments).load(object).then do |ans|
+          ans.each do |c|
+            c.cache_user!(user)
+          end
+          ans
+        end
       else
         nil
       end
@@ -128,14 +133,12 @@ module Types
     field :all_grading_comments, [Types::GradingCommentType], null: false
     def all_grading_comments
       if ALL_STAFF_OR_PUBLISHED.call(self, nil, context)
-        AssociationLoader.for(Registration, :grading_comments, includes: [
-          :creator, 
-          :question,
-          :part,
-          :body_item,
-          preset_comment: :rubric_preset,
-          registration: :user,
-        ]).load(object)
+        AssociationLoader.for(Registration, :grading_comments).load(object).then do |ans|
+          ans.each do |c|
+            c.cache_user!(user)
+          end
+          ans
+        end
       else
         nil
       end

--- a/app/models/body_item.rb
+++ b/app/models/body_item.rb
@@ -81,7 +81,7 @@ class BodyItem < ApplicationRecord
   end
 
   def root_rubric
-    rubrics.root_rubrics.first
+    rubrics.body_item_root_rubrics.first
   end
 
   def rubric_as_json(format:)

--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -289,9 +289,10 @@ class Exam < ApplicationRecord
 
   def bottlenose_exam_grades(regs = nil)
     regs = registrations if regs.nil?
+    regs = regs.reject { |r| r.current_answers == r.exam_version.default_answers }
     all_versions = exam_versions.map { |ev| ev.bottlenose_summary(with_names: false) }
     if compatible_versions(all_versions)
-      regs.reject { |r| r.current_answers == r.exam_version.default_answers }.to_h do |r|
+      regs.to_h do |r|
         [
           r.user.username,
           r.current_part_scores,

--- a/app/models/grading_comment.rb
+++ b/app/models/grading_comment.rb
@@ -31,8 +31,16 @@ class GradingComment < ApplicationRecord
     end
   end
 
+  # This method should be called only by registration_type, to
+  # preemptively cache the registration's user without having to
+  # load this object's registration field, to in turn get the user
+  # to check in visible_to? below.
+  def cache_user!(reg_user)
+    @user = reg_user
+  end
+
   def visible_to?(check_user, role_for_exam, _role_for_course)
-    (user == check_user) ||
+    ((@user || user) == check_user) ||
       (role_for_exam >= Exam.roles[:staff]) ||
       course.all_staff.exists?(check_user.id)
   end

--- a/app/models/part.rb
+++ b/app/models/part.rb
@@ -29,9 +29,7 @@ class Part < ApplicationRecord
   end
 
   def root_rubric
-    rubrics.where(
-      body_item: nil,
-    ).root_rubrics.first
+    rubrics.part_root_rubrics.first
   end
 
   def as_json(format:)

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -28,10 +28,7 @@ class Question < ApplicationRecord
   end
 
   def root_rubric
-    rubrics.where(
-      part: nil,
-      body_item: nil,
-    ).root_rubrics.first
+    rubrics.question_root_rubrics.first
   end
 
   def as_json(format:)

--- a/app/models/rubric.rb
+++ b/app/models/rubric.rb
@@ -37,6 +37,10 @@ class Rubric < ApplicationRecord
           source: 'ancestor'
 
   scope :root_rubrics, -> { joins(:ancestor_links).group('id').having('count(rubrics.id) = 1') }
+  scope :exam_version_root_rubrics, -> { root_rubrics.where(question_id: nil, part_id: nil, body_item_id: nil) }
+  scope :question_root_rubrics, -> { root_rubrics.where(part_id: nil, body_item_id: nil) }
+  scope :part_root_rubrics, -> { root_rubrics.where(body_item_id: nil) }
+  scope :body_item_root_rubrics, -> { root_rubrics }
 
   before_create do
     self_link = RubricTreePath.new(ancestor: self, descendant: self, path_length: 0)
@@ -138,7 +142,7 @@ class Rubric < ApplicationRecord
     question && part && body_item.nil?
   end
 
-  def body_rubric
+  def body_rubric?
     question && part && body_item && true
   end
 

--- a/app/packs/components/workflows/professor/exams/stats/index.tsx
+++ b/app/packs/components/workflows/professor/exams/stats/index.tsx
@@ -56,6 +56,9 @@ const ExamStats: React.FC<{
   const examVersionsMap = new Map(
     examVersions.map((v) => [v.id, v]),
   );
+  const regsById: Map<Registration['id'], Registration> = new Map(
+    registrations.filter((r) => r.started).map((r) => [r.id, r]),
+  );
   const regsByVersion: Map<ExamVersion['id'], Registration[]> = new Map(
     Array.from(examVersionsMap.keys()).map(
       (id) => [id, registrations.filter((r) => r.examVersion.id === id && r.started)],
@@ -63,7 +66,10 @@ const ExamStats: React.FC<{
   );
   const scoresByRegId: Map<ExamVersion['id'], Map<Registration['id'], RegistrationScore['scores']>> = new Map(
     examVersions.map(
-      (v) => [v.id, new Map(v.currentScores.map((reg) => [reg.registration.id, reg.scores]))],
+      (v) => [
+        v.id,
+        new Map(v.currentScores.filter((reg) => regsById.get(reg.registration.id)?.started)
+          .map((reg) => [reg.registration.id, reg.scores]))],
     ),
   );
   const statsByVersion: Record<ExamVersion['id'], number[][]> = {};
@@ -195,7 +201,14 @@ const RenderVersionStats: React.FC<{
       .map((q) => q.parts.filter((p) => !p.extraCredit).map((p) => p.points))
       .flat(),
   );
-  const scoresByRegId: Map<Registration['id'], RegistrationScore['scores']> = new Map(version.currentScores.map((reg) => [reg.registration.id, reg.scores]));
+  const regsById: Map<Registration['id'], Registration> = new Map(
+    regs.filter((r) => r.started).map((r) => [r.id, r]),
+  );
+  const scoresByRegId: Map<Registration['id'], RegistrationScore['scores']> = new Map(
+    version.currentScores
+      .filter((reg) => regsById.get(reg.registration.id)?.started)
+      .map((reg) => [reg.registration.id, reg.scores]),
+  );
   regs.forEach((r) => {
     const rawScore = d3.sum(scoresByRegId.get(r.id).flat());
     rawScores.push(rawScore);

--- a/app/packs/components/workflows/professor/exams/stats/utils.ts
+++ b/app/packs/components/workflows/professor/exams/stats/utils.ts
@@ -21,8 +21,8 @@ export type PresetUsageData = {
   Total: number,
 };
 
-export type GradingCommentConnection = RubricPresetHistograms$data['registrations'][number]['gradingComments'];
-export type GradingComment = GradingCommentConnection['edges'][number]['node'];
+export type GradingCommentList = RubricPresetHistograms$data['registrations'][number]['allGradingComments'];
+export type GradingComment = GradingCommentList[number];
 
 export const colors = [
   'steelblue', 'maroon', 'gold', 'seagreen', 'orange', 'indigo',

--- a/config/schemas/exam-upload.json
+++ b/config/schemas/exam-upload.json
@@ -417,7 +417,6 @@
     "TextPrompt": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["prompt"],
       "properties": {
         "prompt": { "$ref": "#/definitions/HTML" },
         "correctAnswer": { "type": "string" },


### PR DESCRIPTION
This seems to have a roughly 10x improvement (so far) in the query performance of the stats page, on an exam with ~95 students.  I think it'll be even more pronounced for larger exams, so I *think* it's eliminated all the `O(#students) ` GraphQL-related queries.